### PR TITLE
Recent dev additions and various bug fixes to anisotropy and vorticity AMR

### DIFF
--- a/fieldsolver/derivatives.cpp
+++ b/fieldsolver/derivatives.cpp
@@ -812,14 +812,15 @@ void calculateScaledDeltas(
    // Now, rotation matrix to get parallel and perpendicular pressure
    //Eigen::Quaterniond q {Quaterniond::FromTwoVectors(Eigen::vector3d{0, 0, 1}, Eigen::vector3d{myB[0], myB[1], myB[2]})};
    //Eigen::Matrix3d rot = q.toRotationMatrix();
-   Eigen::Matrix3d rot = Eigen::Quaterniond::FromTwoVectors(Eigen::Vector3d{0, 0, 1}, Eigen::Vector3d{myB[0], myB[1], myB[2]}).toRotationMatrix();
+   Eigen::Matrix3d rot = Eigen::Quaterniond::FromTwoVectors(Eigen::Vector3d{myB[0], myB[1], myB[2]}, Eigen::Vector3d{0, 0, 1}).normalized().toRotationMatrix();
    Eigen::Matrix3d P {
       {cell->parameters[CellParams::P_11], cell->parameters[CellParams::P_12], cell->parameters[CellParams::P_13]},
       {cell->parameters[CellParams::P_12], cell->parameters[CellParams::P_22], cell->parameters[CellParams::P_23]},
       {cell->parameters[CellParams::P_13], cell->parameters[CellParams::P_23], cell->parameters[CellParams::P_33]},
    };
    
-   Eigen::Matrix3d Pprime = rot * P * rot.transpose();
+   Eigen::Matrix3d transposerot = rot.transpose();
+   Eigen::Matrix3d Pprime = rot * P * transposerot;
 
    Real Panisotropy {0.0};
    if (Pprime(2, 2) > EPS) {

--- a/fieldsolver/derivatives.cpp
+++ b/fieldsolver/derivatives.cpp
@@ -836,7 +836,7 @@ void calculateScaledDeltas(
    Real vorticity {std::sqrt(std::pow(dVxdy - dVydz, 2) + std::pow(dVxdz - dVzdx, 2 ) + std::pow(dVydx - dVxdy, 2))};
    //Real vA {std::sqrt(Bsq / (physicalconstants::MU_0 * myRho))};
    Real amr_vorticity {0.0};
-   if (maxV > eps) {
+   if (maxV > EPS) {
       amr_vorticity = vorticity * cell->parameters[CellParams::DX] / maxV;
    }
 

--- a/grid.cpp
+++ b/grid.cpp
@@ -517,7 +517,51 @@ void balanceLoad(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, S
    
    /*transfer cells in parts to preserve memory*/
    phiprof::Timer transfersTimer {"Data transfers"};
-   const uint64_t num_part_transfers=5;
+
+   // Idea: do as many cell sending passes hereafter so that there's not more than transfer_block_fraction_limit
+   // blocks of this task's total block count that gets sent. Helps in reducing memory peaks during load balancing.
+   creal transfer_block_fraction_limit = 0.1;
+   uint64_t num_part_transfers_local = 1, num_part_transfers, outgoing_block_count = 0, total_block_count = 0;
+   bool count_determined = false;
+   Real outgoing_block_fraction;
+
+   // count blocks
+   for (unsigned int i=0; i<outgoing_cells_list.size(); i++) {
+      CellID cell_id=outgoing_cells_list[i];
+      SpatialCell* cell = mpiGrid[cell_id];
+      outgoing_block_count += cell->get_number_of_all_velocity_blocks();
+   }
+   for (unsigned int i=0; i<cells.size(); i++) {
+      CellID cell_id=cells[i];
+      SpatialCell* cell = mpiGrid[cell_id];
+      total_block_count += cell->get_number_of_all_velocity_blocks();
+   }
+   outgoing_block_fraction = (Real)outgoing_block_count / ((Real)total_block_count + 1);
+   // if we're not exceeding transfer_block_fraction_limit we're good
+   if(outgoing_block_fraction < transfer_block_fraction_limit) {
+      count_determined = true;
+   }
+   // otherwise we increase the number of chunks until all chunks are below transfer_block_fraction_limit
+   while(!count_determined) {
+      for (uint64_t transfer_part=0; transfer_part<num_part_transfers_local; transfer_part++) {
+         uint64_t transfer_part_block_count=0;
+         for (unsigned int i=0;i<outgoing_cells_list.size();i++){
+            CellID cell_id=outgoing_cells_list[i];
+            if (cell_id%num_part_transfers_local==transfer_part) {
+               transfer_part_block_count += mpiGrid[cell_id]->get_number_of_all_velocity_blocks();
+            }
+         }
+         outgoing_block_fraction = (Real)transfer_part_block_count / ((Real)total_block_count + 1);
+         if(outgoing_block_fraction > transfer_block_fraction_limit) {
+            num_part_transfers_local *= 2;
+            break; // out of for
+         }
+      }
+      count_determined = true; // we got a break out if any chunk was still too big
+   }
+   // ...and finally we reduce this across all tasks of course.
+   MPI_Allreduce(&num_part_transfers_local, &num_part_transfers, 1, MPI_UINT64_T, MPI_MAX, MPI_COMM_WORLD);
+
    for (uint64_t transfer_part=0; transfer_part<num_part_transfers; transfer_part++) {
       //Set transfers on/off for the incoming cells in this transfer set and prepare for receive
       for (unsigned int i=0;i<incoming_cells_list.size();i++){

--- a/grid.cpp
+++ b/grid.cpp
@@ -558,8 +558,8 @@ void balanceLoad(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, S
             break; // out of for
          }
       }
-      if(transfer_part == num_part_transfers_local // either the loop ended or we hit that number with the *= 2
-         && outgoing_block_fraction <= transfer_block_fraction_limit // so cross-check with this
+      if((transfer_part == num_part_transfers_local // either the loop ended or we hit that number with the *= 2
+         && outgoing_block_fraction <= transfer_block_fraction_limit) // so cross-check with this
          || num_part_transfers_local >= cells.size()
       ) {
          count_determined = true; // we got a break out if any chunk was still too big

--- a/grid.cpp
+++ b/grid.cpp
@@ -560,6 +560,7 @@ void balanceLoad(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid, S
       }
       if(transfer_part == num_part_transfers_local // either the loop ended or we hit that number with the *= 2
          && outgoing_block_fraction <= transfer_block_fraction_limit // so cross-check with this
+         || num_part_transfers_local >= cells.size()
       ) {
          count_determined = true; // we got a break out if any chunk was still too big
       }

--- a/parameters.cpp
+++ b/parameters.cpp
@@ -167,10 +167,11 @@ Real P::alpha1CoarsenThreshold = -1.0;
 bool P::useAlpha2 = true;
 Real P::alpha2RefineThreshold = 0.5;
 Real P::alpha2CoarsenThreshold = -1.0;
-bool P::useVorticity = true;
+bool P::useVorticity = false;
 Real P::vorticityRefineThreshold = 0.5;
 Real P::vorticityCoarsenThreshold = -1.0;
-Real P::anisotropyRefineThreshold = -1;
+bool P::useAnisotropy = false;
+Real P::anisotropyRefineThreshold = 0.5;
 int P::anisotropyMaxReflevel = 2;
 Real P::alphaDRhoWeight = 1.0;
 Real P::alphaDUWeight = 1.0;
@@ -489,10 +490,11 @@ bool P::addParameters() {
    RP::add("AMR.use_alpha2","Use J/B_perp as a refinement index", true);
    RP::add("AMR.alpha2_refine_threshold","Determines the minimum value of alpha_2 to refine cells", 0.5);
    RP::add("AMR.alpha2_coarsen_threshold","Determines the maximum value of alpha_2 to unrefine cells, default half of the refine threshold", -1.0);
-   RP::add("AMR.use_vorticity","Use vorticity as a refinement index", true);
+   RP::add("AMR.use_vorticity","Use vorticity as a refinement index", false);
    RP::add("AMR.vorticity_refine_threshold","Determines the minimum value of vorticity to refine cells", 0.5);
    RP::add("AMR.vorticity_coarsen_threshold","Determines the maximum value of vorticity to unrefine cells, default half of the refine threshold", -1.0);
-   RP::add("AMR.anisotropy_refine_threshold","Determines the maximum value of pressure anisotropy to refine cells", -1.0);
+   RP::add("AMR.use_anisotropy","Use pressure anisotropy as a refinement index", false);
+   RP::add("AMR.anisotropy_refine_threshold","Determines the maximum value of pressure anisotropy to refine cells", 0.5);
    RP::add("AMR.anisotropy_max_reflevel","When anisotropy is below the refine threshold, defines the maximum level to refine to", 2);
    RP::add("AMR.refine_cadence","Refine every nth load balance", 5);
    RP::add("AMR.refine_after","Start refinement after this many simulation seconds", 0.0);
@@ -825,8 +827,15 @@ void Parameters::getParameters() {
       MPI_Abort(MPI_COMM_WORLD, 1);
    }
 
+   RP::get("AMR.use_anisotropy",P::useAnisotropy);
    RP::get("AMR.anisotropy_refine_threshold", P::anisotropyRefineThreshold);
    RP::get("AMR.anisotropy_max_reflevel", P::anisotropyMaxReflevel);
+   if (P::useAnisotropy && P::anisotropyRefineThreshold < 0) {
+      if (myRank == MASTER_RANK) {
+         cerr << "ERROR invalid anisotropy refine threshold" << endl;
+      }
+      MPI_Abort(MPI_COMM_WORLD, 1);
+   }
 
    RP::get("AMR.refine_cadence",P::refineCadence);
    RP::get("AMR.refine_after",P::refineAfter);

--- a/parameters.h
+++ b/parameters.h
@@ -202,6 +202,7 @@ struct Parameters {
    static bool useVorticity;
    static Real vorticityRefineThreshold;
    static Real vorticityCoarsenThreshold;
+   static bool useAnisotropy;
    static Real anisotropyRefineThreshold;
    static int anisotropyMaxReflevel;
    static uint refineCadence;

--- a/projects/project.cpp
+++ b/projects/project.cpp
@@ -649,7 +649,7 @@ namespace projects {
                      (P::useAlpha1 ? mpiGrid[neighbor]->parameters[CellParams::AMR_ALPHA1] > P::alpha1RefineThreshold : false) || 
                      (P::useAlpha2 ? mpiGrid[neighbor]->parameters[CellParams::AMR_ALPHA2] > P::alpha2RefineThreshold : false) ||
                      (P::useVorticity ? mpiGrid[neighbor]->parameters[CellParams::AMR_VORTICITY] > P::vorticityRefineThreshold : false) ||
-                     (P::anisotropyRefineThreshold > 0 && cell->parameters[CellParams::P_ANISOTROPY] < P::anisotropyRefineThreshold && refLevel < P::anisotropyMaxReflevel)
+                     (P::anisotropyRefineThreshold > 0 && mpiGrid[neighbor]->parameters[CellParams::P_ANISOTROPY] < P::anisotropyRefineThreshold && neighborRef < P::anisotropyMaxReflevel)
                   )};
                if (shouldRefineNeighbor &&
                   // If the neighbor is planned to be refined, but is outside the allowed refinement region, cancel that refinement.

--- a/projects/project.cpp
+++ b/projects/project.cpp
@@ -612,7 +612,7 @@ namespace projects {
             };
 
             // Pressure anisotropy forces refinement when under threshold
-            if (P::anisotropyRefineThreshold > 0 && cell->parameters[CellParams::P_ANISOTROPY] < P::anisotropyRefineThreshold && refLevel < P::anisotropyMaxReflevel) {
+            if (r2 < r_max2 && P::anisotropyRefineThreshold > 0 && cell->parameters[CellParams::P_ANISOTROPY] < P::anisotropyRefineThreshold && refLevel < P::anisotropyMaxReflevel) {
                shouldRefine = true;
                shouldUnrefine = false;
             }
@@ -648,7 +648,8 @@ namespace projects {
                   (neighborR2 < r_max2) && (
                      (P::useAlpha1 ? mpiGrid[neighbor]->parameters[CellParams::AMR_ALPHA1] > P::alpha1RefineThreshold : false) || 
                      (P::useAlpha2 ? mpiGrid[neighbor]->parameters[CellParams::AMR_ALPHA2] > P::alpha2RefineThreshold : false) ||
-                     (P::useVorticity ? mpiGrid[neighbor]->parameters[CellParams::AMR_VORTICITY] > P::vorticityRefineThreshold : false)
+                     (P::useVorticity ? mpiGrid[neighbor]->parameters[CellParams::AMR_VORTICITY] > P::vorticityRefineThreshold : false) ||
+                     (P::anisotropyRefineThreshold > 0 && cell->parameters[CellParams::P_ANISOTROPY] < P::anisotropyRefineThreshold && refLevel < P::anisotropyMaxReflevel)
                   )};
                if (shouldRefineNeighbor &&
                   // If the neighbor is planned to be refined, but is outside the allowed refinement region, cancel that refinement.

--- a/projects/project.cpp
+++ b/projects/project.cpp
@@ -612,7 +612,7 @@ namespace projects {
             };
 
             // Pressure anisotropy forces refinement when under threshold
-            if (r2 < r_max2 && P::anisotropyRefineThreshold > 0 && cell->parameters[CellParams::P_ANISOTROPY] < P::anisotropyRefineThreshold && refLevel < P::anisotropyMaxReflevel) {
+            if (r2 < r_max2 && P::useAnisotropy && cell->parameters[CellParams::P_ANISOTROPY] < P::anisotropyRefineThreshold && refLevel < P::anisotropyMaxReflevel) {
                shouldRefine = true;
                shouldUnrefine = false;
             }
@@ -649,7 +649,7 @@ namespace projects {
                      (P::useAlpha1 ? mpiGrid[neighbor]->parameters[CellParams::AMR_ALPHA1] > P::alpha1RefineThreshold : false) || 
                      (P::useAlpha2 ? mpiGrid[neighbor]->parameters[CellParams::AMR_ALPHA2] > P::alpha2RefineThreshold : false) ||
                      (P::useVorticity ? mpiGrid[neighbor]->parameters[CellParams::AMR_VORTICITY] > P::vorticityRefineThreshold : false) ||
-                     (P::anisotropyRefineThreshold > 0 && mpiGrid[neighbor]->parameters[CellParams::P_ANISOTROPY] < P::anisotropyRefineThreshold && neighborRef < P::anisotropyMaxReflevel)
+                     (P::useAnisotropy ? mpiGrid[neighbor]->parameters[CellParams::P_ANISOTROPY] < P::anisotropyRefineThreshold && neighborRef < P::anisotropyMaxReflevel : false)
                   )};
                if (shouldRefineNeighbor &&
                   // If the neighbor is planned to be refined, but is outside the allowed refinement region, cancel that refinement.

--- a/spatial_cell_cpu.cpp
+++ b/spatial_cell_cpu.cpp
@@ -743,7 +743,7 @@ namespace spatial_cell {
          // Refinement parameters
          if ((SpatialCell::mpi_transfer_type & Transfer::REFINEMENT_PARAMETERS)){
             displacements.push_back(reinterpret_cast<uint8_t*>(this->parameters.data() + CellParams::AMR_ALPHA1) - reinterpret_cast<uint8_t*>(this));
-            block_lengths.push_back(sizeof(Real) * (CellParams::AMR_VORTICITY - CellParams::AMR_ALPHA1 + 1)); // This is just 2, but let's be explicit
+            block_lengths.push_back(sizeof(Real) * (CellParams::AMR_VORTICITY - CellParams::AMR_ALPHA1 + 1)); // This is just 4, but let's be explicit.
          }
 
          // Copy random number generator state variables

--- a/spatial_cell_cpu.cpp
+++ b/spatial_cell_cpu.cpp
@@ -743,7 +743,7 @@ namespace spatial_cell {
          // Refinement parameters
          if ((SpatialCell::mpi_transfer_type & Transfer::REFINEMENT_PARAMETERS)){
             displacements.push_back(reinterpret_cast<uint8_t*>(this->parameters.data() + CellParams::AMR_ALPHA1) - reinterpret_cast<uint8_t*>(this));
-            block_lengths.push_back(sizeof(Real) * (CellParams::AMR_ALPHA2 - CellParams::AMR_ALPHA1 + 1)); // This is just 2, but let's be explicit
+            block_lengths.push_back(sizeof(Real) * (CellParams::AMR_VORTICITY - CellParams::AMR_ALPHA1 + 1)); // This is just 2, but let's be explicit
          }
 
          // Copy random number generator state variables

--- a/vlasovsolver/cpu_moments.cpp
+++ b/vlasovsolver/cpu_moments.cpp
@@ -56,6 +56,9 @@ void calculateCellMoments(spatial_cell::SpatialCell* cell,
       cell->parameters[CellParams::P_11] = 0.0;
       cell->parameters[CellParams::P_22] = 0.0;
       cell->parameters[CellParams::P_33] = 0.0;
+      cell->parameters[CellParams::P_23] = 0.0;
+      cell->parameters[CellParams::P_13] = 0.0;
+      cell->parameters[CellParams::P_12] = 0.0;
    }
 
     // Loop over all particle species
@@ -187,6 +190,9 @@ void calculateMoments_R(
              cell->parameters[CellParams::P_11_R] = 0.0;
              cell->parameters[CellParams::P_22_R] = 0.0;
              cell->parameters[CellParams::P_33_R] = 0.0;
+             cell->parameters[CellParams::P_23_R] = 0.0;
+             cell->parameters[CellParams::P_13_R] = 0.0;
+             cell->parameters[CellParams::P_12_R] = 0.0;
           }
 
           vmesh::VelocityBlockContainer<vmesh::LocalID>& blockContainer = cell->get_velocity_blocks(popID);
@@ -341,6 +347,9 @@ void calculateMoments_V(
              cell->parameters[CellParams::P_11_V] = 0.0;
              cell->parameters[CellParams::P_22_V] = 0.0;
              cell->parameters[CellParams::P_33_V] = 0.0;
+             cell->parameters[CellParams::P_23_V] = 0.0;
+             cell->parameters[CellParams::P_13_V] = 0.0;
+             cell->parameters[CellParams::P_12_V] = 0.0;
          }
 
          vmesh::VelocityBlockContainer<vmesh::LocalID>& blockContainer = cell->get_velocity_blocks(popID);


### PR DESCRIPTION
The following things were changed:

- Added some fixes and features from dev
- Remove unnecessary calculation of bulkV for vorticity, normalise vorticity by local bulkV or, failing that, max neighbour bulkV or, failing that, set vorticity to 0.
- Fixed rotation matrix direction (want B to be rotated to (0,0,1), not vice versa), made tensor rotation potentially safer by doing transpose beforehand, and added a catch for division by 0.
- Turned vorticity AMR off by default, added on/off switch for anisotropy, and changed default anisotropy threshold to 0.5. Added a catch for invalid threshold.
- Limited anisotropy AMR to within rmax, and added possibility of neighbor refining for anisotropy. Fixed communication of AMR cellparams.
- Fixed off-diagonal pressure tensor components not being cleared properly.